### PR TITLE
Add support for regional instance groups

### DIFF
--- a/docs/tutorials/multinode/terraform/htcondor/startup-centos.sh
+++ b/docs/tutorials/multinode/terraform/htcondor/startup-centos.sh
@@ -169,7 +169,6 @@ fi
 service google-fluentd restart
 
 # Add Python Libraries and Autoscaler
-
 if [ "$SERVER_TYPE" == "submit" ]; then
   python3 -m pip install --upgrade oauth2client
   python3 -m pip install --upgrade google-api-python-client
@@ -181,7 +180,7 @@ EOFZ
 
 # Create cron entry for autoscaler. Log to /var/log/messages
 
-echo "* * * * * python3 /opt/autoscaler.py --p ${project} --z ${zone} --g ${cluster_name} --c ${max_replicas} | logger " |crontab -
+echo "* * * * * python3 /opt/autoscaler.py --p ${project} --z ${zone} --r ${region} %{ if multizone }--mz %{ endif }--g ${cluster_name} --c ${max_replicas} | logger " |crontab -
 
 fi
 

--- a/docs/tutorials/multinode/terraform/init.sh
+++ b/docs/tutorials/multinode/terraform/init.sh
@@ -4,7 +4,8 @@ export TF_VAR_project=quantum-htcondor-15
 export TF_VAR_project_id=us-east4-c
 export TF_VAR_zone=us-east4-c
 export TF_VAR_region=us-east4
-
+export TF_VAR_multizone=true
+export TF_VAR_numzones=4  # for regional/multizone, set to the number of regions in the zone
 # ---- Do not edit below -----#
 
 export TF_VAR_project_id=${TF_VAR_project}

--- a/docs/tutorials/multinode/terraform/main.tf
+++ b/docs/tutorials/multinode/terraform/main.tf
@@ -4,6 +4,16 @@ variable "project" {
 variable "zone" {
   type=string
 }
+variable "region" {
+  type=string
+}
+variable "multizone" {
+  type=bool
+}
+variable "numzones" {
+  type=string
+}
+
 variable "cluster_name" {
   type = string
   default = "c"
@@ -16,6 +26,9 @@ module "htcondor" {
   cluster_name = var.cluster_name
   project = var.project
   zone = var.zone
+  region = var.region
+  multizone = var.multizone
+  numzones = var.numzones
   osversion = "7"
   max_replicas=20
   min_replicas=0


### PR DESCRIPTION
To enable regional (rather than zonal) instance groups, set
TF_VAR_multizone to True and TF_VAR_numzones to the number
of zones in the region.